### PR TITLE
Fix no bracket match after else / else if

### DIFF
--- a/autoload/closer.vim
+++ b/autoload/closer.vim
@@ -134,17 +134,17 @@ function! s:get_closing(line)
     if ch == '{'
       let clo = '}' . clo
     elseif ch == '}'
-      if clo[0] != '}' | return '' | endif
+      " if clo[0] != '}' | return '' | endif
       let clo = clo[1:]
     elseif ch == '('
       let clo = ')' . clo
     elseif ch == ')'
-      if clo[0] != ')' | return '' | endif
+      " if clo[0] != ')' | return '' | endif
       let clo = clo[1:]
     elseif ch == '['
       let clo = ']' . clo
     elseif ch == ']'
-      if clo[0] != ']' | return '' | endif
+      " if clo[0] != ']' | return '' | endif
       let clo = clo[1:]
     endif
   endwhile


### PR DESCRIPTION
Currently when typing e.g.:

```
if (true) {
    // ...
} else {
    // ...
} <-- this brace will be missing!
```

Changed few lines to try out whether I can easily fix it.
